### PR TITLE
SVN does not like the Lets Encrypt SSL cert currently served on svn.k…

### DIFF
--- a/r5159/Dockerfile
+++ b/r5159/Dockerfile
@@ -13,7 +13,7 @@ RUN locale-gen en_US && \
 RUN cd /usr/local && \
 	mkdir /usr/local/src/kannel && \
 	cd /usr/local/src/kannel && \
-	svn checkout -r 5159 https://svn.kannel.org/gateway/trunk && \
+	svn checkout --non-interactive --trust-server-cert -r 5159 https://svn.kannel.org/gateway/trunk && \
 	mv trunk gateway && \
 	cd /usr/local/src/kannel/gateway && \
 	./configure -prefix=/usr/local/kannel -with-mysql -with-mysql-dir=/usr/lib/mysql/ -enable-debug -enable-assertions -with-defaults=speed \

--- a/r5173/Dockerfile
+++ b/r5173/Dockerfile
@@ -13,7 +13,7 @@ RUN locale-gen en_US && \
 RUN cd /usr/local && \
 	mkdir /usr/local/src/kannel && \
 	cd /usr/local/src/kannel && \
-	svn checkout -r 5173 https://svn.kannel.org/gateway/trunk && \
+	svn checkout --non-interactive --trust-server-cert -r 5173 https://svn.kannel.org/gateway/trunk && \
 	mv trunk gateway && \
 	cd /usr/local/src/kannel/gateway && \
 	./configure -prefix=/usr/local/kannel -with-mysql -with-mysql-dir=/usr/lib/mysql/ -enable-debug -enable-assertions -with-defaults=speed \


### PR DESCRIPTION
…annel.org:443

Causes docker build to fail